### PR TITLE
Add automated accessibility testing for color contrast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  accessibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: opportunities/package-lock.json
+
+      - name: Install dependencies
+        working-directory: opportunities
+        run: npm ci
+
+      - name: Install Playwright
+        working-directory: opportunities
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tests
+        working-directory: opportunities
+        run: npm test
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: opportunities/playwright-report/

--- a/opportunities/package.json
+++ b/opportunities/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "dependencies": {
     "@vueform/vueform": "^1.9.2",
@@ -16,6 +18,8 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.8.4",
+    "@playwright/test": "^1.41.0",
     "@vitejs/plugin-vue": "^4.5.2",
     "vite": "^5.0.10"
   }

--- a/opportunities/playwright.config.js
+++ b/opportunities/playwright.config.js
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium-light',
+      use: { ...devices['Desktop Chrome'], colorScheme: 'light' },
+    },
+    {
+      name: 'chromium-dark',
+      use: { ...devices['Desktop Chrome'], colorScheme: 'dark' },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/opportunities/tests/accessibility.spec.js
+++ b/opportunities/tests/accessibility.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Color contrast accessibility', () => {
+
+  test('home page has no contrast violations', async ({ page }, testInfo) => {
+    await page.goto('/');
+    await page.waitForSelector('#app');
+    // Wait for CSS color transitions to complete (body has 0.5s transition)
+    await page.waitForTimeout(600);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2aa'])
+      .analyze();
+
+    const contrastViolations = results.violations.filter(
+      v => v.id === 'color-contrast'
+    );
+
+    // Attach details to report for debugging
+    await testInfo.attach('contrast-violations', {
+      body: JSON.stringify(contrastViolations, null, 2),
+      contentType: 'application/json',
+    });
+
+    expect(contrastViolations).toEqual([]);
+  });
+});
+
+// Specific test targeting the known banner issue
+test.describe('Update Banner', () => {
+  test('should have sufficient contrast', async ({ page }) => {
+    await page.goto('/');
+    // Wait for CSS color transitions to complete
+    await page.waitForTimeout(600);
+
+    const banner = page.locator('.update-banner');
+    if (await banner.isVisible()) {
+      const results = await new AxeBuilder({ page })
+        .include('.update-banner')
+        .analyze();
+
+      const issues = results.violations.filter(v => v.id === 'color-contrast');
+      expect(issues).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
- Add Playwright + axe-core for WCAG 2.1 AA contrast testing
- Test both light and dark color schemes
- Run tests on PR via GitHub Actions
- Tests currently detect existing contrast violations