### PR TITLE
Configure GitHub Actions deployment to Hetzner VPS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+      - test
+
+jobs:
+  deploy:
+    name: ${{ github.ref_name == 'main' && 'Deploy → prod' || 'Deploy → test' }}
+    runs-on: ubuntu-latest
+
+    environment: ${{ github.ref_name == 'main' && 'prod' || 'test' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opportunities/package-lock.json
+
+      - name: Build Vue frontend
+        run: |
+          cd opportunities
+          npm ci
+          npm run build
+
+      - name: Set deployment variables
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "REMOTE_DIR=/opt/cal-prod" >> $GITHUB_ENV
+            echo "SERVICE=cal-prod" >> $GITHUB_ENV
+          else
+            echo "REMOTE_DIR=/opt/cal-test" >> $GITHUB_ENV
+            echo "SERVICE=cal-test" >> $GITHUB_ENV
+          fi
+
+      - name: Write SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Sync code
+        run: |
+          rsync -az \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            --exclude='venv' --exclude='__pycache__' --exclude='*.pyc' \
+            flaskapp/ root@${{ secrets.SERVER_HOST }}:${{ env.REMOTE_DIR }}/
+
+          # wsgi entry point
+          echo "from flask_app import app" | \
+            ssh -i ~/.ssh/deploy_key root@${{ secrets.SERVER_HOST }} \
+            "cat > ${{ env.REMOTE_DIR }}/wsgi.py"
+
+      - name: Restart service
+        run: |
+          ssh -i ~/.ssh/deploy_key root@${{ secrets.SERVER_HOST }} \
+            "chown -R ${{ env.SERVICE }}:${{ env.SERVICE }} ${{ env.REMOTE_DIR }} && \
+             systemctl restart ${{ env.SERVICE }} && \
+             systemctl status ${{ env.SERVICE }} --no-pager"

--- a/flaskapp/flask_app/templates/opportunities/index.html
+++ b/flaskapp/flask_app/templates/opportunities/index.html
@@ -8,8 +8,8 @@
     <script type="text/javascript">
       var CSRF_TOKEN = "{{ csrf_token() }}";
     </script>
-    <script type="module" crossorigin src="{{ url_for('static', filename='dist/assets/index-BWTFvp7_.js') }}"></script>
-    <link rel="stylesheet" crossorigin href="{{ url_for('static', filename='dist/assets/index-VnbOStFQ.css') }}">
+    <script type="module" crossorigin src="{{ url_for('static', filename='dist/assets/index-CbGXI1Ky.js') }}"></script>
+    <link rel="stylesheet" crossorigin href="{{ url_for('static', filename='dist/assets/index-DeumLiDq.css') }}">
   </head>
   <body>
     <div id="app"></div>

--- a/opportunities/package-lock.json
+++ b/opportunities/package-lock.json
@@ -15,8 +15,23 @@
         "vue-router": "^4.3.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.8.4",
+        "@playwright/test": "^1.41.0",
         "@vitejs/plugin-vue": "^4.5.2",
         "vite": "^5.0.10"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -758,6 +773,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1491,6 +1522,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
@@ -2036,6 +2077,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow that deploys to **test** on push to `test` branch and **prod** on push to `main`
- Builds Vue frontend via Vite before each deploy
- Rsyncs app code to server, restarts gunicorn service
- Fixes hardcoded Vite asset filenames in `index.html` to match current build output

## Prerequisites

Two GitHub Environments must exist with secrets configured:
- `prod` and `test`, each with `SSH_PRIVATE_KEY` and `SERVER_HOST`

## Test plan

- [ ] Merge this PR to `test` branch and confirm GitHub Actions deploys successfully
- [ ] Verify https://test-calendar.stonestew.org loads the app
- [ ] Merge `test` → `main` and confirm prod deploy succeeds
- [ ] Verify https://calendar.stonestew.org loads the app

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)