### PR TITLE
Opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
       - test
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: ${{ github.ref_name == 'main' && 'Deploy → prod' || 'Deploy → test' }}


### PR DESCRIPTION
## Summary

- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in the deploy workflow to opt into Node.js 24 now rather than waiting for the forced cutover on June 2nd, 2026

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)