### PR TITLE
Fix hardcoded asset filenames in Flask template on deploy (#16)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,15 @@ jobs:
           npm ci
           npm run build
 
+      - name: Update asset filenames in Flask template
+        run: |
+          JS_FILE=$(basename flaskapp/flask_app/static/dist/assets/index-*.js)
+          CSS_FILE=$(basename flaskapp/flask_app/static/dist/assets/index-*.css)
+          sed -i "s|dist/assets/index-[^'\"]*\.js|dist/assets/${JS_FILE}|g" \
+            flaskapp/flask_app/templates/opportunities/index.html
+          sed -i "s|dist/assets/index-[^'\"]*\.css|dist/assets/${CSS_FILE}|g" \
+            flaskapp/flask_app/templates/opportunities/index.html
+
       - name: Set deployment variables
         run: |
           if [[ "${{ github.ref_name }}" == "main" ]]; then


### PR DESCRIPTION
Add a workflow step that reads the JS and CSS filenames produced by the Vite build and patches them into the Flask template before rsync runs. This ensures the deployed template always references the correct content-hashed bundle rather than whatever was last committed manually.