### PR TITLE
Document deploy procedures + fix .env loading on PythonAnywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This is a two-tier app for the Hays County Master Naturalist chapter: a Vue 3 SP
 
 ## Development
 
-Node version is pinned to 22 via `.nvmrc`. Python deps are in `flaskapp/requirements.txt`.
+Node version is pinned to 22 via `.nvmrc`. If you use nvm, run `nvm use` (no args) in the repo root — it reads `.nvmrc` and switches automatically. On older Node (e.g. 16), `vite build` crashes with `crypto.getRandomValues is not a function`. Python deps are in `flaskapp/requirements.txt`.
 
 **Frontend dev (Vite, hot reload):**
 ```sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Architecture
+
+This is a two-tier app for the Hays County Master Naturalist chapter: a Vue 3 SPA frontend served by a Flask backend that talks to MySQL.
+
+- **`opportunities/`** — Vue 3 + Vite SPA. Uses `vue-router` (web history), `@vueform/vueform` for forms, `vue-final-modal` for modals, axios for API calls. Vite builds into `../flaskapp/flask_app/static/dist` (see `vite.config.js`).
+- **`flaskapp/flask_app/`** — Flask app split into three blueprints registered in `__init__.py`:
+  - `auth.py` — signup/login/logout, password reset via signed token (`itsdangerous.URLSafeTimedSerializer` salted with the user's current password hash, 3-day expiry), and the `admin_required` / `editor_required` decorators. `g.user` is populated per-request from the session in `load_logged_in_user`.
+  - `opportunities.py` — CRUD on opportunities + the catch-all `/` route that serves the SPA via `templates/opportunities/index.html`. Write endpoints are gated by `@editor_required`; non-admins can only modify rows they own.
+  - `users.py` — admin-only user list/role-flag updates.
+- **DB** — MySQL via PyMySQL with `autocommit=True`; all queries use a per-request cursor from `db.get_db()` and named parameters. Two tables, defined in `db.init_db()` (NOT `schema.sql` — that file is unused in the init path): `master_naturalist` (with `admin` and `project_coordinator` boolean flags) and `opportunities` (FK to `master_naturalist.id` via `owner`).
+
+### Cross-cutting things to know
+
+- **CSRF** — Flask-WTF `CSRFProtect` is on. The `after_request` hook in `__init__.py` sets a `CSRF-TOKEN` cookie/header on every response; the Vue app picks it up via an axios response interceptor in `src/main.js` and sends it back as `X-CSRFToken`. Initial token is also injected into `index.html` as `window.CSRF_TOKEN`.
+- **DEV mode CORS** — Setting `DEV=1` adds CORS headers for `http://localhost:5173` (the Vite dev server) including credentials and the CSRF-TOKEN expose header. Without `DEV=1`, the Flask server expects to serve the built SPA itself.
+- **Times** — Datetimes are stored as UTC in MySQL. The backend localizes to `US/Central` (`pytz`) when returning data to the client and parses incoming `YYYY-MM-DD HH:MM` strings (with am/pm suffix handling in `clean_date`) as Central before storing as UTC.
+- **Recurring events** — `opportunities.find_recurring()` expands `recurring_weekly` and `recurring_monthly` opportunities server-side into individual occurrences from 45 days back to 6 months out, before sending to the client. `recurring_monthly` is an integer N meaning "the Nth week of the month."
+- **SPA routing** — `index()` in `opportunities.py` is a catch-all (`/` and `/<path:path>`) so deep links resolve client-side. Don't add Flask routes that would shadow SPA routes defined in `src/main.js`.
+- **Roles** — three tiers, encoded as boolean flags on `master_naturalist`: regular user (read-only API access), `project_coordinator` (can create/edit/delete their own opportunities), `admin` (can edit/delete anyone's, manage users, generate password-reset links). Use `@editor_required` for write endpoints and `@admin_required` for admin-only endpoints — don't roll your own checks.
+
+## Development
+
+Node version is pinned to 22 via `.nvmrc`. Python deps are in `flaskapp/requirements.txt`.
+
+**Frontend dev (Vite, hot reload):**
+```sh
+cd opportunities && npm install && npm run dev   # serves http://localhost:5173
+```
+
+**Backend dev (Flask, separate terminal):**
+```sh
+cd flaskapp
+pip install -r requirements.txt
+export DEV=1                                # required when running Vite separately, enables CORS
+flask --app flask_app init-db               # first time only — drops & recreates tables
+flask --app flask_app run
+```
+DB defaults (override with `DATABASE_URL`/`DATABASE_NAME`/`DATABASE_USER`/`DATABASE_PASSWORD` env vars): `localhost` / `hcmn` / `root` / `armadillo`. Create the `hcmn` database in MySQL before running `init-db`.
+
+**Production build:** `npm run build` from `opportunities/` produces hashed asset filenames in `flaskapp/flask_app/static/dist/assets/`. The `index.html` template references those filenames directly — the deploy workflow rewrites them via `sed` (see `.github/workflows/deploy.yml`). When testing a prod-style build locally, update the `<script>` and `<link>` tags in `templates/opportunities/index.html` to match the new hash, or run the same sed substitution.
+
+## Tests
+
+Playwright + axe-core accessibility tests live in `opportunities/tests/`. The Playwright config auto-starts the Vite dev server, so Flask does NOT need to be running for these tests — they exercise the static SPA shell.
+
+```sh
+cd opportunities
+npm test                              # all tests, both chromium-light and chromium-dark projects
+npm run test:ui                       # interactive UI mode
+npx playwright test accessibility     # filter by name
+npx playwright test --project=chromium-light --grep "color contrast"
+```
+
+CI runs these on PRs to `main` and `dev` (`.github/workflows/test.yml`).
+
+## Deployment
+
+`.github/workflows/deploy.yml` deploys on push:
+- push to `test` → test environment (`/opt/cal-test`, systemd unit `cal-test`)
+- push to `main` → prod environment (`/opt/cal-prod`, systemd unit `cal-prod`)
+
+The flow: build Vue → sed-rewrite asset hashes in `index.html` → rsync `flaskapp/` to the server → write a one-line `wsgi.py` → restart the systemd unit. `dev` is the default working branch; PRs typically target `dev`, and `dev` is later merged to `test` / `main` to deploy.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,8 +1,10 @@
-# Deploying to PythonAnywhere
+# Deploying to PythonAnywhere (legacy environment)
 
-This runbook covers manual deploys of the HCMN app to PythonAnywhere. It was reconstructed and verified end-to-end on 2026-05-17 after the previous (manual-deploy) maintainer left.
+> **Status: legacy.** PythonAnywhere is where the app currently serves production traffic, but the intended future deploy path is the automated GitHub Actions workflow at `.github/workflows/deploy.yml` (pushes to `main` → `/opt/cal-prod`, pushes to `test` → `/opt/cal-test`, both via systemd on a self-hosted server). The GH Actions workflow does **not** deploy to PythonAnywhere — the two paths are independent.
+>
+> This document exists so that maintenance of the legacy PA deployment remains possible during the interim, and so the procedure isn't lost the next time it's needed.
 
-The unrelated GitHub Actions workflow at `.github/workflows/deploy.yml` targets a different self-hosted systemd setup (`/opt/cal-test`, `/opt/cal-prod`); it does **not** deploy to PythonAnywhere.
+This runbook was reconstructed and verified end-to-end on 2026-05-17 after the previous (manual-deploy) maintainer left.
 
 ## Production environment
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,172 @@
+# Deploying to PythonAnywhere
+
+This runbook covers manual deploys of the HCMN app to PythonAnywhere. It was reconstructed and verified end-to-end on 2026-05-17 after the previous (manual-deploy) maintainer left.
+
+The unrelated GitHub Actions workflow at `.github/workflows/deploy.yml` targets a different self-hosted systemd setup (`/opt/cal-test`, `/opt/cal-prod`); it does **not** deploy to PythonAnywhere.
+
+## Production environment
+
+| Thing | Value |
+|---|---|
+| PA account | `haysmn` |
+| App root on PA | `~/mysite/` |
+| WSGI file | `/var/www/haysmn_pythonanywhere_com_wsgi.py` |
+| Reload mechanism | `touch` the WSGI file (no `systemctl` on PA) |
+| Python interpreter | system `python3` (Python 3.10), packages installed with `pip install --user` |
+| Virtualenv | none — `~/.virtualenvs/` only contains virtualenvwrapper hooks |
+| MySQL host | `haysmn.mysql.pythonanywhere-services.com` |
+| MySQL database | `haysmn$hcmn` (PA prefixes user DBs with `haysmn$`) |
+| MySQL credentials | `~/.my.cnf` (used via `--defaults-file=~/.my.cnf`) |
+| Production env vars | `~/mysite/.env` (loaded by `load_dotenv()` in `flask_app/__init__.py`) |
+
+The WSGI file imports the module-level `app` directly:
+```python
+from flask_app import app as application
+```
+
+## Before you deploy: snapshot
+
+Run this in a PA Bash console **every time** before touching the live app. The rollback step relies on this snapshot.
+
+```sh
+mkdir -p ~/backups
+tar -czf ~/backups/mysite-pre-deploy-$(date +%Y%m%d-%H%M%S).tar.gz -C ~ mysite/
+mysqldump --defaults-file=~/.my.cnf \
+  -h haysmn.mysql.pythonanywhere-services.com \
+  'haysmn$hcmn' > ~/backups/db-$(date +%Y%m%d-%H%M%S).sql
+```
+
+The `mysqldump` PROCESS-privilege warning about tablespaces is harmless on PA — the dump still completes.
+
+Verify the file-tree backup is faithful:
+```sh
+mkdir -p /tmp/verify && rm -rf /tmp/verify/mysite
+tar -xzf ~/backups/mysite-pre-deploy-*.tar.gz -C /tmp/verify
+diff -rq ~/mysite /tmp/verify/mysite   # should print nothing, exit 0
+rm -rf /tmp/verify
+```
+
+## Deploy
+
+### 1. Build the Vue bundle locally
+
+```sh
+cd opportunities
+nvm use                # uses .nvmrc → Node 22; Vite crashes on Node 16
+npm install
+npm run build
+```
+
+This writes new hashed assets into `flaskapp/flask_app/static/dist/assets/`.
+
+### 2. Rewrite asset hashes in the Flask template
+
+`flaskapp/flask_app/templates/opportunities/index.html` references hashed filenames that change on every build. Same sed pattern the GitHub Actions workflow uses:
+
+```sh
+cd ..   # back to repo root
+JS_FILE=$(basename flaskapp/flask_app/static/dist/assets/index-*.js)
+CSS_FILE=$(basename flaskapp/flask_app/static/dist/assets/index-*.css)
+sed -i "s|dist/assets/index-[^'\"]*\.js|dist/assets/${JS_FILE}|g" \
+  flaskapp/flask_app/templates/opportunities/index.html
+sed -i "s|dist/assets/index-[^'\"]*\.css|dist/assets/${CSS_FILE}|g" \
+  flaskapp/flask_app/templates/opportunities/index.html
+```
+
+### 3. Build the deploy tarball
+
+```sh
+cd flaskapp
+tar -czf ~/flask_app-deploy-$(date +%Y%m%d-%H%M%S).tar.gz \
+  --exclude='__pycache__' --exclude='*.pyc' --exclude='schema.sql' \
+  flask_app/
+```
+
+Size is typically ~450KB (mostly the JS bundle). The tarball contains only `flask_app/` — nothing from `instance/` or `.env`, so the swap below won't touch production config.
+
+### 4. Upload via the PA Files UI
+
+1. PA dashboard → **Files** tab
+2. Navigate to `/home/haysmn/`
+3. **Upload a file** → pick the tarball from step 3
+4. Confirm it appears in the listing
+
+### 5. Swap in the new code (PA Bash console)
+
+```sh
+# Sanity check
+ls -lh ~/flask_app-deploy-*.tar.gz
+
+# Park the current flask_app so we can revert fast
+mv ~/mysite/flask_app ~/mysite/flask_app.preswap
+
+# Extract the new code in place
+tar -xzf ~/flask_app-deploy-*.tar.gz -C ~/mysite/
+
+# Confirm contents
+ls -la ~/mysite/flask_app/
+ls -lh ~/mysite/flask_app/static/dist/assets/
+
+# Confirm .env and instance/ are untouched
+ls -la ~/mysite/.env ~/mysite/instance/
+
+# Reload the web app
+touch /var/www/haysmn_pythonanywhere_com_wsgi.py
+```
+
+### 6. Smoke test in the browser
+
+1. Load https://haysmn.pythonanywhere.com/ (first request after a reload can take 5–15s).
+2. Confirm the opportunities list renders — proves `load_dotenv()` populated `DATABASE_URL` and DB queries work.
+3. Log in as a known user — proves `SECRET_KEY` round-trips for sessions and CSRF.
+4. Edit an opportunity (if you have project_coordinator or admin) — proves writes still work and role gating is intact.
+5. Watch the PA error log either via the **Web tab → Log files** UI or `tail -f /var/log/haysmn.pythonanywhere.com.error.log` for tracebacks.
+
+### 7. Cleanup (after the deploy stays healthy)
+
+```sh
+rm -rf ~/mysite/flask_app.preswap
+```
+
+Keep the `~/backups/` snapshots — they're cheap insurance.
+
+## Rollback
+
+If anything is broken after step 5 or 6:
+
+```sh
+rm -rf ~/mysite/flask_app
+mv ~/mysite/flask_app.preswap ~/mysite/flask_app
+touch /var/www/haysmn_pythonanywhere_com_wsgi.py
+```
+
+This works because step 5 deliberately left `~/mysite/flask_app.preswap` in place — the `mv` was a single atomic rename within the same filesystem, so it's instant.
+
+If the issue surfaced later (after step 7 cleanup) or affected the database too, restore from the snapshot tarball + SQL dump instead:
+
+```sh
+# Code: extract the snapshot and atomically swap
+mkdir -p ~/staging && rm -rf ~/staging/mysite
+tar -xzf ~/backups/mysite-pre-deploy-<timestamp>.tar.gz -C ~/staging
+mv ~/mysite ~/mysite.old
+mv ~/staging/mysite ~/mysite
+rmdir ~/staging
+
+# DB: restore the SQL dump
+mysql --defaults-file=~/.my.cnf \
+  -h haysmn.mysql.pythonanywhere-services.com \
+  'haysmn$hcmn' < ~/backups/db-<timestamp>.sql
+
+# Reload
+touch /var/www/haysmn_pythonanywhere_com_wsgi.py
+
+# After confirming the rolled-back app is healthy:
+rm -rf ~/mysite.old
+```
+
+## Gotchas
+
+- **`load_dotenv()` is mandatory for PA.** The PA WSGI process doesn't source a shell, so without it `~/mysite/.env` is silently ignored and the app starts with `DATABASE_URL=None`. The call lives in `flask_app/__init__.py` and is a no-op when the file is missing, so it's safe to keep for the systemd deployment too.
+- **The Vue build needs Node 22.** Node 16 will crash with `crypto.getRandomValues is not a function`. Run `nvm use` to pick up `.nvmrc`.
+- **Downloading PA tarballs decompresses them in transit.** If you grab one via the Files UI, extract with `tar -xf` (not `tar -xzf`) — the `.tar.gz` extension is stale. Uploads to PA are not affected.
+- **`schema.sql` is unused.** The DB tables come from `db.init_db()` Python code, not from `schema.sql`. Safe to exclude from deploy tarballs.

--- a/flaskapp/flask_app/__init__.py
+++ b/flaskapp/flask_app/__init__.py
@@ -1,9 +1,14 @@
 import os
 
+from dotenv import load_dotenv
 from flask import Flask
 from flask_wtf.csrf import CSRFProtect, generate_csrf
 from . import auth, db, opportunities, users
 
+
+# PythonAnywhere's WSGI process doesn't source a shell; without this, the
+# .env one level above the package would be silently ignored in prod.
+load_dotenv(os.path.join(os.path.dirname(__file__), os.pardir, '.env'))
 
 app = Flask(__name__, instance_relative_config=True)
 

--- a/flaskapp/requirements.txt
+++ b/flaskapp/requirements.txt
@@ -8,6 +8,7 @@ Jinja2==3.1.3
 MarkupSafe==2.1.5
 PyMySQL==1.1.0
 python-dateutil==2.9.0.post0
+python-dotenv==1.0.1
 pytz==2024.1
 six==1.16.0
 Werkzeug==3.0.1


### PR DESCRIPTION
## Summary

Bundles five commits that have accumulated on this branch — three about deployment, two about onboarding docs:

- **`a44d5e9` — Load `.env` on startup.** PythonAnywhere's WSGI process doesn't source a shell, so `~/mysite/.env` was previously silently ignored on PA; the running app on PA had an uncommitted `load_dotenv()` patch in `__init__.py`. This commit moves that patch into source and adds `python-dotenv==1.0.1` to `flaskapp/requirements.txt`. The call is positioned to read `flaskapp/.env` (one level above the package) so it works the same way for local dev. It no-ops harmlessly when the file is missing or when vars are already set, so it's safe for the systemd/GH-Actions deploy target too.
- **`b4b9ee1` + `5d3d806` — `DEPLOY.md`.** A reference runbook for the legacy PythonAnywhere deployment (build → sed asset hashes → tar → upload via Files UI → swap → touch WSGI → smoke test, plus the verified rollback). Framed as legacy reference — the intended future deploy path remains `.github/workflows/deploy.yml`.
- **`8325d9c` + `c1f66a1` — `CLAUDE.md`.** Architecture and dev-workflow notes added earlier in the branch; includes the Node-version pitfall (`nvm use` / Vite crash on Node 16).

## Test plan

- [x] The `load_dotenv()` change has already been deployed to PythonAnywhere and verified end-to-end on 2026-05-17: home page renders (DB connectivity OK), login succeeds (SECRET_KEY/sessions OK), editing an opportunity succeeds (write path OK).
- [x] `python3 -m py_compile flaskapp/flask_app/__init__.py` passes locally.
- [ ] CI test workflow (Playwright + axe-core) passes on this PR.
- [ ] Reviewer skim of `DEPLOY.md` for accuracy if anyone else still touches PA.

## Notes for reviewers

- The PA runbook in `DEPLOY.md` is positioned as **legacy reference** — the project's intended deploy path is `.github/workflows/deploy.yml`. The two are independent; the dotenv fix works for either.
- Unrelated heads-up: pushing this branch surfaced 30 Dependabot alerts on the default branch (6 high / 22 moderate / 2 low). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)