### PR TITLE
Sync dev: recurrence edit/monthly fix + pending test commits

### DIFF
--- a/flaskapp/flask_app/opportunities.py
+++ b/flaskapp/flask_app/opportunities.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
 from flask import (
-    Blueprint, g, render_template, request
+    Blueprint, current_app, g, render_template, request
 )
 from pytz import timezone
 from werkzeug.exceptions import abort
@@ -118,7 +118,10 @@ def find_recurring(opportunities):
     six_months_out = now + relativedelta(months=6)
     fortyfive_days_ago = now - timedelta(days=45)
 
-    for opp in opportunities:
+    # Expand one opportunity into all_opportunities. A closure so the loop below
+    # can wrap each call: one malformed recurrence must never raise out of the
+    # public list endpoint and blank the whole calendar for everyone.
+    def expand(opp):
         expiration_date = opp.get('expiration_date')
 
         if opp['recurring_weekly']:
@@ -147,6 +150,14 @@ def find_recurring(opportunities):
 
         elif opp['recurring_monthly']:
             # adds opp every month for 3 months out (accounting for expiration_date).
+            # recurring_monthly is the Nth week (1-5) of the month; (N-1)*7 is used
+            # below as a day-of-month floor, so a value >5 makes that floor exceed
+            # every real date and the advance loop never terminates. Skip such rows.
+            if not 1 <= opp['recurring_monthly'] <= 5:
+                current_app.logger.warning(
+                    "find_recurring: skipping opp %s with out-of-range "
+                    "recurring_monthly=%s", opp.get('id'), opp['recurring_monthly'])
+                return
             day = opp['event_start']
             original_hour = day.astimezone(central).hour
             at_least_date = (opp['recurring_monthly'] - 1) * 7
@@ -163,6 +174,13 @@ def find_recurring(opportunities):
             # adds non-recurring opps as-is.
             convert_to_local_time(opp)
             all_opportunities.append(opp)
+
+    for opp in opportunities:
+        try:
+            expand(opp)
+        except Exception:
+            current_app.logger.exception(
+                "find_recurring: skipping opportunity %s", opp.get('id'))
 
     return all_opportunities
 
@@ -194,6 +212,22 @@ def clean_recurring_days(form):
             if d:
                 days.append(d)
     return ','.join(days) if days else None
+
+
+def clean_recurring_monthly(value):
+    '''Validate the monthly-recurrence value, or None when blank.
+
+    recurring_monthly is the Nth occurrence (1-5) of the event's weekday each
+    month. find_recurring expands it using (N-1)*7 as a day-of-month floor, so
+    only 1-5 are meaningful; anything outside that range is rejected here so a
+    bad value can never reach the expansion loop.'''
+    if not value:
+        return None
+    n = int(value)  # ValueError on non-numeric -> 400 via the caller's handler
+    if not 1 <= n <= 5:
+        raise ValueError('recurring_monthly must be between 1 and 5')
+    return n
+
 
 def clean_date(dt):
     '''Convert a Central-time date/datetime string to a UTC datetime.
@@ -288,7 +322,7 @@ def create():
                     'category': request.form['category'],
                     'project_id': request.form['at_category'] if request.form['category'] == 'AT' else request.form.get('project_id'),
                     'recurring_weekly': 1 if request.form.get('recurring_weekly') == 'true' else 0,
-                    'recurring_monthly': request.form.get('recurring_monthly') or None,
+                    'recurring_monthly': clean_recurring_monthly(request.form.get('recurring_monthly')),
                     'recurring_days': clean_recurring_days(request.form),
                     'link': request.form.get('link') or None,
                     'just_show_up': 1 if request.form.get('just_show_up') == 'true' else 0,
@@ -371,7 +405,7 @@ def update(id):
                     'category': request.form['category'],
                     'project_id': request.form['at_category'] if request.form['category'] == 'AT' else request.form.get('project_id'),
                     'recurring_weekly': 1 if request.form.get('recurring_weekly') == 'true' else 0,
-                    'recurring_monthly': request.form.get('recurring_monthly') or None,
+                    'recurring_monthly': clean_recurring_monthly(request.form.get('recurring_monthly')),
                     'recurring_days': clean_recurring_days(request.form),
                     'link': request.form.get('link') or None,
                     'just_show_up': 1 if request.form.get('just_show_up') == 'true' else 0,

--- a/opportunities/src/components/Opportunities.vue
+++ b/opportunities/src/components/Opportunities.vue
@@ -47,8 +47,8 @@ const isHydratingFilters = ref(true)
 
 // App update banner (manual version/date + description)
 // Bump APP_UPDATE_DATE (YYYY-MM-DD) and APP_UPDATE_DESC whenever you ship a notable UI/app change.
-const APP_UPDATE_DATE = '2026-05-14'
-const APP_UPDATE_DESC = 'Try the new "Start week on Sunday" feature!'
+const APP_UPDATE_DATE = '2026-06-07'
+const APP_UPDATE_DESC = 'Try the new "Start week on Sunday" feature! Also, notice that your checked options remain every visit.'
 const UPDATE_COOKIE_KEY = 'opportunities_last_seen_update'
 const showUpdateBanner = ref(false)
 

--- a/opportunities/src/components/Opportunities.vue
+++ b/opportunities/src/components/Opportunities.vue
@@ -212,7 +212,7 @@ function removeExpired(opps) {
       expirationDate = opp.expiration_date || opp.event_start
     }
 
-    return !expirationDate || moment() <= moment(expirationDate)
+    return !expirationDate || moment().isSameOrBefore(moment(expirationDate), 'day')
   })
 }
 

--- a/opportunities/src/components/OpportunityForm.vue
+++ b/opportunities/src/components/OpportunityForm.vue
@@ -33,6 +33,14 @@ const selectedWeekdayName = computed(() => {
 function setType(val) {
   currentType.value = val
   if (form$.value?.el$('type')) form$.value.el$('type').update(val)
+  // recurring_weekly/anytime are derived from the type. Their :value props only
+  // seed the elements, so once form.load() has set them on an edit they no longer
+  // track the type — push the derived values explicitly, same as `type` above.
+  if (form$.value?.el$('recurring_weekly')) form$.value.el$('recurring_weekly').update(val === 'weekly')
+  if (form$.value?.el$('anytime')) form$.value.el$('anytime').update(val === 'anytime')
+  // Clear the monthly value when the type isn't monthly so a leftover number
+  // can't make a one-day/weekly event expand as monthly in find_recurring.
+  if (val !== 'monthly' && form$.value?.el$('recurring_monthly')) form$.value.el$('recurring_monthly').update(null)
 }
 
 function toggleDay(val) {
@@ -194,7 +202,7 @@ onMounted(async () => {
 
           <DateElement name="ui_start_time" label="Start Time" :date="false" :time="true" value-format="HH:mm" display-format="hh:mm a" :conditions="[['type', '!=', 'anytime']]" @change="syncDatetime" />
           <DateElement name="ui_end_time" label="End Time" :date="false" :time="true" value-format="HH:mm" display-format="hh:mm a" :conditions="[['type', '!=', 'anytime']]" @change="syncDatetime" />
-          <TextElement name="recurring_monthly" label="Day of Month" :conditions="[['type', '==', 'monthly']]" />
+          <TextElement name="recurring_monthly" label="Week of the month (1-5)" rules="required|numeric|min:1|max:5" :conditions="[['type', '==', 'monthly']]" />
           <DateElement name="expiration_date" label="Expiration Date" :time="false" value-format="YYYY-MM-DD" :conditions="[['type', '!=', 'once']]" />
 
           <TextElement name="link" label="Sign Up Link" />


### PR DESCRIPTION
Fast-forwards `dev` up to `185cb0c`, which is what `test` and `main` are already at. `dev` had drifted behind, missing both these commits and the recurrence fix.

Commits dev gains:
- **185cb0c** Fix recurrence editing: persist type changes and guard monthly expansion (the hotfix already live on PA, test, and main)
- **2cb91d2** Update the app-update banner notice
- **267a241** Show today's earlier-in-the-day events on the calendar

No new changes here — this is purely to realign `dev` with the deployed branches and stop the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)